### PR TITLE
Add DateRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-06-11
+
+### Added
+- `DateRange` class for working with date ranges
+- Support for date range operations:
+  - Creating date ranges with inclusive/exclusive bounds
+  - Checking if a date is contained in a range
+  - Checking if date ranges overlap
+  - Calculating date range length
+  - Creating unions and intersections of date ranges
+  - Generating series of dates within a range
+  - Comparing date ranges for equality
+  - Splitting date ranges at specific points
+  - Shifting date ranges by time intervals
+- Custom step intervals (days, weeks, months, etc.) for date ranges
+- Documentation for DateRange
+
 ## [0.0.1] - 2025-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This class uses the BCMath extension for all operations, ensuring accurate calcu
 
 For detailed documentation on the BigIntRange class, see [BigIntRange Documentation](doc/BigIntRange.md).
 
+### DateRange
+
+The `DateRange` class allows you to represent and manipulate date ranges. It offers a complete API for creating, comparing, and transforming ranges of dates using DateTimeImmutable objects.
+
+This class supports custom step intervals (days, weeks, months, etc.) for generating date series and provides operations for date range manipulation.
+
+For detailed documentation on the DateRange class, see [DateRange Documentation](doc/DateRange.md).
+
 ## Quick Examples
 
 ### IntRange Example
@@ -62,6 +70,41 @@ $shifted = $range->shift('1000000000000000000');
 
 $scaled = $range->scale('2');
 // $scaled now represents [18446744073709551616, 18446744073709551636]
+```
+
+### DateRange Example
+
+```php
+use Ciloe\Ranges\DateRange;
+use DateTimeImmutable;
+use DateInterval;
+
+// Create a date range from 2023-01-01 to 2023-01-10
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-10'),
+    '[',
+    ']'
+);
+
+// Check if a date is in the range
+$range->contains(new DateTimeImmutable('2023-01-05')); // true
+
+// Generate a series of dates in the range (with default 1-day step)
+$dates = $range->generateSeries(); // Array of DateTimeImmutable objects from 2023-01-01 to 2023-01-10
+
+// Create a range with weekly steps
+$weeklyRange = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-31'),
+    '[',
+    ']',
+    new DateInterval('P1W')
+);
+$weeklyDates = $weeklyRange->generateSeries(); // [2023-01-01, 2023-01-08, 2023-01-15, 2023-01-22, 2023-01-29]
+
+// Shift a date range
+$shifted = $range->shift(new DateInterval('P1M')); // [2023-02-01, 2023-02-10]
 ```
 
 ## Exceptions

--- a/doc/DateRange.md
+++ b/doc/DateRange.md
@@ -1,0 +1,193 @@
+# DateRange
+
+The `DateRange` class allows you to represent and manipulate date ranges. It offers a complete API for creating, comparing, and transforming ranges of dates.
+
+## Basic Usage
+
+```php
+use Ciloe\Ranges\DateRange;
+
+// Create a range from 2023-01-01 to 2023-01-10
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-10'),
+    '[',
+    ']'
+);
+
+// Check if a date is in the range
+$range->contains(new DateTimeImmutable('2023-01-05')); // true
+$range->contains(new DateTimeImmutable('2023-01-15')); // false
+
+// Get the length of the range (number of days)
+$range->length(); // 10
+
+// Generate a series of dates in the range
+$dates = $range->generateSeries(); // Array of DateTimeImmutable objects from 2023-01-01 to 2023-01-10
+
+// Create a range with a specific step (every 2 days)
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-10'),
+    '[',
+    ']',
+    new DateInterval('P2D')
+);
+$dates = $range->generateSeries(); // [2023-01-01, 2023-01-03, 2023-01-05, 2023-01-07, 2023-01-09]
+```
+
+## Creating Ranges
+
+### Constructor
+
+```php
+new DateRange(
+    ?DateTimeImmutable $lower = null,     // Lower bound (null for -∞)
+    ?DateTimeImmutable $upper = null,     // Upper bound (null for +∞)
+    string $lowerBound = '(',             // Lower bound type: '[' (inclusive) or '(' (exclusive)
+    string $upperBound = ')',             // Upper bound type: ']' (inclusive) or ')' (exclusive)
+    DateInterval $step = new DateInterval('P1D') // Step for series generation (default: 1 day)
+);
+```
+
+### From a String
+
+```php
+// Format: (lower,upper) where parentheses can be [ or ] for inclusion
+// Dates are in Y-m-d format
+DateRange::fromString('(2023-01-01,2023-01-10)');  // Range (2023-01-01,2023-01-10) - exclusive
+DateRange::fromString('[2023-01-01,2023-01-10]');  // Range [2023-01-01,2023-01-10] - inclusive
+DateRange::fromString('(,2023-01-10]');            // Range (-∞,2023-01-10]
+DateRange::fromString('[2023-01-01,)');            // Range [2023-01-01,+∞)
+DateRange::fromString('(,)');                      // Range (-∞,+∞)
+```
+
+## Main Methods
+
+### Verification and Properties
+
+- `isEmpty()` : Checks if the range is empty
+- `isBoundsValid()` : Checks if the bounds are valid (lower ≤ upper)
+- `getLowerBoundValue()` : Returns the effective value of the lower bound
+- `getUpperBoundValue()` : Returns the effective value of the upper bound
+- `contains(DateTimeInterface $value)` : Checks if a date is in the range
+- `length()` : Calculates the length of the range (number of days)
+- `getStep()` : Returns the step interval
+
+### Operations Between Ranges
+
+- `overlap(DateRange $range)` : Checks if two ranges overlap
+- `union(DateRange $range)` : Calculates the union of two ranges
+- `intersection(DateRange $range)` : Calculates the intersection of two ranges
+- `equals(DateRange $range)` : Checks if two ranges are equal
+
+### Transformations
+
+- `generateSeries()` : Generates an array of dates in the range
+- `split(DateTimeInterface $point)` : Divides the range into two at the specified date
+- `clone()` : Creates a copy of the range
+- `shift(DateInterval $offset)` : Shifts the range by the specified time interval
+- `scale(DateInterval $factor)` : This function is not supported for DateRange
+- `__toString()` : Converts the range to a string
+
+## Advanced Examples
+
+### Range Manipulation
+
+```php
+// Intersection of two ranges
+$range1 = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-15'),
+    '[',
+    ']'
+);
+$range2 = new DateRange(
+    new DateTimeImmutable('2023-01-10'),
+    new DateTimeImmutable('2023-01-20'),
+    '[',
+    ']'
+);
+$intersection = $range1->intersection($range2); // [2023-01-10,2023-01-15]
+
+// Union of two ranges
+$union = $range1->union($range2); // [2023-01-01,2023-01-20]
+
+// Check overlap
+$range1->overlap($range2); // true
+
+// Split a range
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-10'),
+    '[',
+    ']'
+);
+[$left, $right] = $range->split(new DateTimeImmutable('2023-01-05'));
+// [2023-01-01,2023-01-05) and [2023-01-05,2023-01-10]
+
+// Shift a range
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-10'),
+    '[',
+    ']'
+);
+$shifted = $range->shift(new DateInterval('P5D')); // [2023-01-06,2023-01-15]
+```
+
+### Infinite Ranges
+
+```php
+// Range without lower bound
+$range = new DateRange(
+    null,
+    new DateTimeImmutable('2023-01-10'),
+    '(',
+    ']'
+);
+$range->contains(new DateTimeImmutable('1900-01-01')); // true
+$range->contains(new DateTimeImmutable('2023-01-10')); // true
+$range->contains(new DateTimeImmutable('2023-01-11')); // false
+
+// Range without upper bound
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    null,
+    '[',
+    ')'
+);
+$range->contains(new DateTimeImmutable('2023-01-01')); // true
+$range->contains(new DateTimeImmutable('2100-01-01')); // true
+$range->contains(new DateTimeImmutable('2022-12-31')); // false
+
+// Completely open range
+$range = new DateRange(null, null, '(', ')');
+$range->contains(new DateTimeImmutable('1900-01-01')); // true
+$range->contains(new DateTimeImmutable('2023-01-01')); // true
+$range->contains(new DateTimeImmutable('2100-01-01')); // true
+```
+
+### Working with Different Step Intervals
+
+```php
+// Create a range with monthly steps
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-06-01'),
+    '[',
+    ']',
+    new DateInterval('P1M')
+);
+$dates = $range->generateSeries(); // [2023-01-01, 2023-02-01, 2023-03-01, 2023-04-01, 2023-05-01, 2023-06-01]
+
+// Create a range with weekly steps
+$range = new DateRange(
+    new DateTimeImmutable('2023-01-01'),
+    new DateTimeImmutable('2023-01-31'),
+    '[',
+    ']',
+    new DateInterval('P1W')
+);
+$dates = $range->generateSeries(); // [2023-01-01, 2023-01-08, 2023-01-15, 2023-01-22, 2023-01-29]
+```

--- a/src/BigIntRange.php
+++ b/src/BigIntRange.php
@@ -12,7 +12,7 @@ use Exception;
 use InvalidArgumentException;
 
 /**
- * @implements RangeInterface<string>
+ * @implements RangeInterface<string, string>
  */
 class BigIntRange implements RangeInterface
 {
@@ -130,6 +130,10 @@ class BigIntRange implements RangeInterface
 
     public function overlap(RangeInterface $range): bool
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of BigIntRange');
+        }
+
         if ($this->isEmpty() || $range->isEmpty()) {
             return false;
         }
@@ -168,8 +172,12 @@ class BigIntRange implements RangeInterface
         return $length;
     }
 
-    public function union(RangeInterface $range): ?RangeInterface
+    public function union(RangeInterface $range): ?self
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of BigIntRange');
+        }
+
         if (bccomp($this->getStep(), $range->getStep()) !== 0) {
             return null;
         }
@@ -194,8 +202,12 @@ class BigIntRange implements RangeInterface
         return new self($lower, $upper, '[', ']', $this->getStep());
     }
 
-    public function intersection(RangeInterface $range): ?RangeInterface
+    public function intersection(RangeInterface $range): ?self
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of BigIntRange');
+        }
+
         if (bccomp($this->getStep(), $range->getStep()) !== 0) {
             return null;
         }
@@ -277,6 +289,10 @@ class BigIntRange implements RangeInterface
 
     public function equals(RangeInterface $range): bool
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of BigIntRange');
+        }
+
         return $this->getLowerBoundValue() === $range->getLowerBoundValue() &&
                $this->getUpperBoundValue() === $range->getUpperBoundValue() &&
                $this->getStep() === $range->getStep();

--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ciloe\Ranges;
+
+use Ciloe\Ranges\Exception\CantGenerateSeriesBecauseTheArrayIsTooLarge;
+use Ciloe\Ranges\Exception\InvalidBoundException;
+use Ciloe\Ranges\Exception\InvalidInfiniteBoundException;
+use DateInterval;
+use DateMalformedStringException;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+/**
+ * @implements RangeInterface<DateTimeImmutable, DateInterval>
+ */
+class DateRange implements RangeInterface
+{
+    public function __construct(
+        readonly public ?DateTimeImmutable $lower = null,
+        readonly public ?DateTimeImmutable $upper = null,
+        readonly public string $lowerBound = '(',
+        readonly public string $upperBound = ')',
+        public DateInterval $step = new DateInterval('P1D'),
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $lowerValue = $this->lower === null ? '' : $this->lower->format('Y-m-d');
+        $upperValue = $this->upper === null ? '' : $this->upper->format('Y-m-d');
+
+        return $this->lowerBound . $lowerValue . ',' . $upperValue . $this->upperBound;
+    }
+
+    /**
+     * @throws DateMalformedStringException
+     */
+    public static function fromString(string $range): self
+    {
+        if (
+            ! preg_match(
+                '/^(\[|\()([0-9]{4}-[0-9]{2}-[0-9]{2}|null)?,([0-9]{4}-[0-9]{2}-[0-9]{2}|null)?(\]|\))$/',
+                $range,
+                $matches,
+            )
+        ) {
+            throw new InvalidArgumentException('Invalid range format');
+        }
+
+        $lowerBound = $matches[1];
+        $lowerStr = $matches[2];
+        $upperStr = $matches[3];
+        $upperBound = $matches[4];
+
+        $lower = ($lowerStr === 'null' || $lowerStr === '') ? null : new DateTimeImmutable($lowerStr);
+        $upper = ($upperStr === 'null' || $upperStr === '') ? null : new DateTimeImmutable($upperStr);
+
+        if (($lower === null && $lowerBound === '[') || ($upper === null && $upperBound === ']')) {
+            throw new InvalidInfiniteBoundException();
+        }
+
+        $range = new self($lower, $upper, $lowerBound, $upperBound);
+
+        if (! $range->isBoundsValid()) {
+            throw new InvalidBoundException();
+        }
+
+        return $range;
+    }
+
+    public function isEmpty(): bool
+    {
+        if ($this->lower === null || $this->upper === null) {
+            return false;
+        }
+
+        $lowerValue = $this->getLowerBoundValue();
+        $upperValue = $this->getUpperBoundValue();
+
+        if ($lowerValue === null || $upperValue === null) {
+            return false;
+        }
+
+        return $lowerValue == $upperValue &&
+            ($this->lowerBound === '(' || $this->upperBound === ')');
+    }
+
+    public function isBoundsValid(): bool
+    {
+        $lower = $this->getLowerBoundValue();
+        $upper = $this->getUpperBoundValue();
+
+        if ($lower === null || $upper === null) {
+            return true;
+        }
+
+        return $lower <= $upper;
+    }
+
+    public function getLowerBoundValue(): ?DateTimeImmutable
+    {
+        if ($this->lower === null) {
+            return null;
+        }
+
+        if ($this->lowerBound === '[') {
+            return $this->lower;
+        }
+
+        return (clone $this->lower)->add($this->getStep());
+    }
+
+    public function getUpperBoundValue(): ?DateTimeImmutable
+    {
+        if ($this->upper === null) {
+            return null;
+        }
+
+        if ($this->upperBound === ']') {
+            return $this->upper;
+        }
+
+        return (clone $this->upper)->sub($this->getStep());
+    }
+
+    /**
+     * @param DateTimeInterface $value
+     */
+    public function contains(mixed $value): bool
+    {
+        if (! $value instanceof DateTimeInterface) {
+            throw new InvalidArgumentException('Value must be a DateTimeInterface instance');
+        }
+
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        if ($value instanceof DateTime) {
+            $value = DateTimeImmutable::createFromMutable($value);
+        }
+
+        $lower = $this->getLowerBoundValue();
+        $upper = $this->getUpperBoundValue();
+
+        if ($lower === null && $upper === null) {
+            return true;
+        }
+
+        if ($lower === null) {
+            return $value <= $upper;
+        }
+
+        if ($upper === null) {
+            return $value >= $lower;
+        }
+
+        return $value >= $lower && $value <= $upper;
+    }
+
+    public function overlap(RangeInterface $range): bool
+    {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of DateRange');
+        }
+
+        if ($this->isEmpty() || $range->isEmpty()) {
+            return false;
+        }
+
+        $a1 = $this->getLowerBoundValue();
+        $a2 = $this->getUpperBoundValue();
+        $b1 = $range->getLowerBoundValue();
+        $b2 = $range->getUpperBoundValue();
+
+        if ($a1 === null && $b2 === null) {
+            return true;
+        }
+        if ($a2 === null && $b1 === null) {
+            return true;
+        }
+        if ($a1 === null && $b1 === null) {
+            return true;
+        }
+        if ($a2 === null && $b2 === null) {
+            return true;
+        }
+
+        if ($a1 === null) {
+            return $a2 >= $b1;
+        }
+        if ($a2 === null) {
+            return $b2 >= $a1;
+        }
+        if ($b1 === null) {
+            return $b2 >= $a1;
+        }
+        if ($b2 === null) {
+            return $a2 >= $b1;
+        }
+
+        return $a2 >= $b1 && $b2 >= $a1;
+    }
+
+    public function length(): ?int
+    {
+        $lower = $this->getLowerBoundValue();
+        $upper = $this->getUpperBoundValue();
+
+        if ($lower === null || $upper === null) {
+            return null;
+        }
+
+        if ($lower > $upper) {
+            return 0;
+        }
+
+        $diff = $lower->diff($upper);
+        $days = $diff->days + 1;
+
+        $stepDays = $this->getStepDays();
+        $length = (int) ceil($days / $stepDays);
+
+        return max($length, 0);
+    }
+
+    public function union(RangeInterface $range): ?self
+    {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of DateRange');
+        }
+
+        if (! $this->isSameStepUnit($range)) {
+            return null;
+        }
+
+        $thisLower = $this->getLowerBoundValue();
+        $thisUpper = $this->getUpperBoundValue();
+        $rangeLower = $range->getLowerBoundValue();
+        $rangeUpper = $range->getUpperBoundValue();
+
+        $lower = $this->minDate($thisLower, $rangeLower);
+        $upper = $this->maxDate($thisUpper, $rangeUpper);
+
+        return new self($lower, $upper, '[', ']', $this->getStep());
+    }
+
+    public function intersection(RangeInterface $range): ?self
+    {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of DateRange');
+        }
+
+        if (! $this->isSameStepUnit($range)) {
+            return null;
+        }
+
+        $thisLower = $this->getLowerBoundValue();
+        $thisUpper = $this->getUpperBoundValue();
+        $rangeLower = $range->getLowerBoundValue();
+        $rangeUpper = $range->getUpperBoundValue();
+
+        $lower = $this->maxDate($thisLower, $rangeLower);
+        $upper = $this->minDate($thisUpper, $rangeUpper);
+
+        if ($lower !== null && $upper !== null && $lower > $upper) {
+            return null;
+        }
+
+        return new self($lower, $upper, '[', ']', $this->getStep());
+    }
+
+    /**
+     * @return DateTimeImmutable[]
+     */
+    public function generateSeries(): array
+    {
+        if ($this->isEmpty()) {
+            return [];
+        }
+
+        $lower = $this->getLowerBoundValue();
+        $upper = $this->getUpperBoundValue();
+
+        if ($lower === null || $upper === null) {
+            throw new CantGenerateSeriesBecauseTheArrayIsTooLarge();
+        }
+
+        if ($lower > $upper) {
+            return [];
+        }
+
+        $series = [];
+        $current = clone $lower;
+
+        while ($current <= $upper) {
+            $series[] = clone $current;
+            $current = $current->add($this->getStep());
+        }
+
+        return $series;
+    }
+
+    public function equals(RangeInterface $range): bool
+    {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of DateRange');
+        }
+
+        $thisLower = $this->getLowerBoundValue();
+        $thisUpper = $this->getUpperBoundValue();
+        $rangeLower = $range->getLowerBoundValue();
+        $rangeUpper = $range->getUpperBoundValue();
+
+        if (
+            ($thisLower === null && $rangeLower !== null) ||
+            ($thisLower !== null && $rangeLower === null)
+        ) {
+            return false;
+        }
+        if ($thisLower !== null && $rangeLower !== null && $thisLower != $rangeLower) {
+            return false;
+        }
+
+        if (
+            ($thisUpper === null && $rangeUpper !== null) ||
+            ($thisUpper !== null && $rangeUpper === null)
+        ) {
+            return false;
+        }
+        if ($thisUpper !== null && $rangeUpper !== null && $thisUpper != $rangeUpper) {
+            return false;
+        }
+
+        return $this->isSameStepUnit($range);
+    }
+
+    /**
+     * @param DateTimeImmutable $point
+     * @return array<DateRange>
+     */
+    public function split(mixed $point): array
+    {
+        if (! $point instanceof DateTimeInterface) {
+            throw new InvalidArgumentException('Point must be a DateTimeInterface instance');
+        }
+
+        if (! $this->contains($point)) {
+            return [$this];
+        }
+
+        $leftRange = new self(
+            $this->lower,
+            $point,
+            $this->lowerBound,
+            ')',
+            $this->getStep()
+        );
+
+        $rightRange = new self(
+            $point,
+            $this->upper,
+            '[',
+            $this->upperBound,
+            $this->getStep()
+        );
+
+        return [$leftRange, $rightRange];
+    }
+
+    public function clone(): self
+    {
+        return new self(
+            $this->lower,
+            $this->upper,
+            $this->lowerBound,
+            $this->upperBound,
+            $this->getStep()
+        );
+    }
+
+    /**
+     * @param DateInterval $offset
+     */
+    public function shift(mixed $offset): self
+    {
+        if (! $offset instanceof DateInterval) {
+            throw new InvalidArgumentException('Offset must be a DateInterval instance');
+        }
+
+        $newLower = $this->lower?->add($offset);
+        $newUpper = $this->upper?->add($offset);
+
+        return new self(
+            $newLower,
+            $newUpper,
+            $this->lowerBound,
+            $this->upperBound,
+            $this->getStep()
+        );
+    }
+
+    /**
+     * @param DateInterval $factor
+     */
+    public function scale(mixed $factor): self
+    {
+        throw new InvalidArgumentException('Scale operation is not supported for DateRange');
+    }
+
+    public function getStep(): DateInterval
+    {
+        return $this->step;
+    }
+
+    private function getStepDays(): int
+    {
+        $reference = new DateTimeImmutable();
+        $after = $reference->add($this->getStep());
+
+        return (int) $reference->diff($after)->days;
+    }
+
+    private function isSameStepUnit(self $range): bool
+    {
+        return $this->getStepDays() === $range->getStepDays();
+    }
+
+    private function minDate(?DateTimeImmutable $date1, ?DateTimeImmutable $date2): ?DateTimeImmutable
+    {
+        if ($date1 === null) {
+            return $date2;
+        }
+        if ($date2 === null) {
+            return $date1;
+        }
+
+        return $date1 < $date2 ? $date1 : $date2;
+    }
+
+    private function maxDate(?DateTimeImmutable $date1, ?DateTimeImmutable $date2): ?DateTimeImmutable
+    {
+        if ($date1 === null) {
+            return $date1;
+        }
+        if ($date2 === null) {
+            return $date2;
+        }
+
+        return $date1 > $date2 ? $date1 : $date2;
+    }
+}

--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -6,9 +6,9 @@ namespace Ciloe\Ranges;
 
 use Ciloe\Ranges\Exception\CantGenerateSeriesBecauseTheArrayIsTooLarge;
 use Ciloe\Ranges\Exception\InvalidBoundException;
+use Ciloe\Ranges\Exception\InvalidDateIntervalException;
 use Ciloe\Ranges\Exception\InvalidInfiniteBoundException;
 use DateInterval;
-use DateMalformedStringException;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -19,6 +19,9 @@ use InvalidArgumentException;
  */
 class DateRange implements RangeInterface
 {
+    /**
+     * @throws InvalidDateIntervalException
+     */
     public function __construct(
         readonly public ?DateTimeImmutable $lower = null,
         readonly public ?DateTimeImmutable $upper = null,
@@ -26,6 +29,7 @@ class DateRange implements RangeInterface
         readonly public string $upperBound = ')',
         public DateInterval $step = new DateInterval('P1D'),
     ) {
+        $this->validateDateInterval($step);
     }
 
     public function __toString(): string
@@ -36,9 +40,6 @@ class DateRange implements RangeInterface
         return $this->lowerBound . $lowerValue . ',' . $upperValue . $this->upperBound;
     }
 
-    /**
-     * @throws DateMalformedStringException
-     */
     public static function fromString(string $range): self
     {
         if (
@@ -385,12 +386,15 @@ class DateRange implements RangeInterface
 
     /**
      * @param DateInterval $offset
+     * @throws InvalidDateIntervalException
      */
     public function shift(mixed $offset): self
     {
         if (! $offset instanceof DateInterval) {
             throw new InvalidArgumentException('Offset must be a DateInterval instance');
         }
+
+        $this->validateDateInterval($offset);
 
         $newLower = $this->lower?->add($offset);
         $newUpper = $this->upper?->add($offset);
@@ -415,6 +419,16 @@ class DateRange implements RangeInterface
     public function getStep(): DateInterval
     {
         return $this->step;
+    }
+
+    /**
+     * @throws InvalidDateIntervalException
+     */
+    private function validateDateInterval(DateInterval $interval): void
+    {
+        if ($interval->h !== 0 || $interval->i !== 0 || $interval->s !== 0 || $interval->f !== 0.0) {
+            throw new InvalidDateIntervalException();
+        }
     }
 
     private function getStepDays(): int

--- a/src/Exception/InvalidDateIntervalException.php
+++ b/src/Exception/InvalidDateIntervalException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ciloe\Ranges\Exception;
+
+use InvalidArgumentException;
+
+class InvalidDateIntervalException extends InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'DateInterval must not contain minutes, hours, or seconds.
+            Only days, months, and years are allowed.'
+        );
+    }
+}

--- a/src/IntRange.php
+++ b/src/IntRange.php
@@ -12,7 +12,7 @@ use Exception;
 use InvalidArgumentException;
 
 /**
- * @implements RangeInterface<int>
+ * @implements RangeInterface<int, int>
  */
 class IntRange implements RangeInterface
 {
@@ -103,6 +103,10 @@ class IntRange implements RangeInterface
 
     public function overlap(RangeInterface $range): bool
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of IntRange');
+        }
+
         if ($this->isEmpty() || $range->isEmpty()) {
             return false;
         }
@@ -134,6 +138,10 @@ class IntRange implements RangeInterface
 
     public function union(RangeInterface $range): ?self
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of IntRange');
+        }
+
         if ($this->getStep() !== $range->getStep()) {
             return null;
         }
@@ -148,6 +156,10 @@ class IntRange implements RangeInterface
 
     public function intersection(RangeInterface $range): ?self
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of IntRange');
+        }
+
         if ($this->getStep() !== $range->getStep()) {
             return null;
         }
@@ -195,6 +207,10 @@ class IntRange implements RangeInterface
 
     public function equals(RangeInterface $range): bool
     {
+        if (! $range instanceof self) {
+            throw new InvalidArgumentException('Range must be an instance of IntRange');
+        }
+
         return $this->getLowerBoundValue() === $range->getLowerBoundValue() &&
                $this->getUpperBoundValue() === $range->getUpperBoundValue() &&
                $this->getStep() === $range->getStep();
@@ -206,6 +222,10 @@ class IntRange implements RangeInterface
      */
     public function split($point): array
     {
+        if (! is_int($point)) {
+            throw new InvalidArgumentException('Split point must be an integer');
+        }
+
         if (! $this->contains($point)) {
             return [$this];
         }
@@ -262,6 +282,10 @@ class IntRange implements RangeInterface
      */
     public function scale($factor): self
     {
+        if (! is_int($factor)) {
+            throw new InvalidArgumentException('Factor must be an integer');
+        }
+
         if ($factor === 0) {
             throw new InvalidArgumentException('Scale factor cannot be zero');
         }

--- a/src/RangeInterface.php
+++ b/src/RangeInterface.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 
 /**
  * @template T
+ * @template Y
  */
 interface RangeInterface
 {
@@ -23,7 +24,7 @@ interface RangeInterface
     /**
      * Will return an object representation of the range
      *
-     * @return RangeInterface<T> The range class
+     * @return RangeInterface<T, Y> The range class
      * @throws InvalidArgumentException If the range is invalid
      * @throws InvalidInfiniteBoundException When the includes bounds are used with infinite bounds
      * @throws InvalidBoundException When the upper bound is lower than the lower bound
@@ -49,14 +50,14 @@ interface RangeInterface
      *
      * @return T|null The lower bound value, or null if unbounded
      */
-    public function getLowerBoundValue();
+    public function getLowerBoundValue(): mixed;
 
     /**
      * Gets the effective upper bound value.
      *
      * @return T|null The upper bound value, or null if unbounded
      */
-    public function getUpperBoundValue();
+    public function getUpperBoundValue(): mixed;
 
     /**
      * Checks if the range contains a value.
@@ -70,8 +71,9 @@ interface RangeInterface
     /**
      * Checks if this range overlaps with another range.
      *
-     * @param RangeInterface<T> $range The range to check for overlap
+     * @param RangeInterface<T, Y> $range The range to check for overlap
      * @return bool True if the ranges overlap, false otherwise
+     * @throws InvalidArgumentException If the value is invalid
      */
     public function overlap(self $range): bool;
 
@@ -85,16 +87,18 @@ interface RangeInterface
     /**
      * Creates a union of this range with another range.
      *
-     * @param RangeInterface<T> $range The range to union with
-     * @return RangeInterface<T>|null The union range, or null if the ranges cannot be unioned
+     * @param RangeInterface<T, Y> $range The range to union with
+     * @return RangeInterface<T, Y>|null The union range, or null if the ranges cannot be unioned
+     * @throws InvalidArgumentException If the value is invalid
      */
     public function union(self $range): ?self;
 
     /**
      * Creates an intersection of this range with another range.
      *
-     * @param RangeInterface<T> $range The range to intersect with
-     * @return RangeInterface<T>|null The intersection range, or null if the ranges do not intersect
+     * @param RangeInterface<T, Y> $range The range to intersect with
+     * @return RangeInterface<T, Y>|null The intersection range, or null if the ranges do not intersect
+     * @throws InvalidArgumentException If the value is invalid
      */
     public function intersection(self $range): ?self;
 
@@ -110,8 +114,9 @@ interface RangeInterface
     /**
      * Checks if this range equals another range.
      *
-     * @param RangeInterface<T> $range The range to compare with
+     * @param RangeInterface<T, Y> $range The range to compare with
      * @return bool True if the ranges are equal, false otherwise
+     * @throws InvalidArgumentException If the value is invalid
      */
     public function equals(self $range): bool;
 
@@ -119,7 +124,7 @@ interface RangeInterface
      * Splits the range at a specific point.
      *
      * @param T $point The point to split at
-     * @return array<RangeInterface<T>> An array of ranges resulting from the split
+     * @return array<RangeInterface<T, Y>> An array of ranges resulting from the split
      * @throws InvalidArgumentException If the point is invalid
      */
     public function split(mixed $point): array;
@@ -127,15 +132,15 @@ interface RangeInterface
     /**
      * Creates a clone of this range.
      *
-     * @return RangeInterface<T> The cloned range
+     * @return RangeInterface<T, Y> The cloned range
      */
     public function clone(): self;
 
     /**
      * Creates a new range by shifting this range by an offset.
      *
-     * @param T $offset The offset to shift by
-     * @return RangeInterface<T> The shifted range
+     * @param Y $offset The offset to shift by
+     * @return RangeInterface<T, Y> The shifted range
      * @throws InvalidArgumentException If the offset is invalid
      */
     public function shift(mixed $offset): self;
@@ -143,8 +148,8 @@ interface RangeInterface
     /**
      * Creates a new range by scaling this range by a factor.
      *
-     * @param T $factor The factor to scale by
-     * @return RangeInterface<T> The scaled range
+     * @param Y $factor The factor to scale by
+     * @return RangeInterface<T, Y> The scaled range
      * @throws InvalidArgumentException If the factor is invalid
      */
     public function scale(mixed $factor): self;
@@ -152,7 +157,7 @@ interface RangeInterface
     /**
      * Gets the step value used for generating series and calculating length.
      *
-     * @return T The step value
+     * @return Y The step value
      */
     public function getStep(): mixed;
 }

--- a/tests/DateRangeTest.php
+++ b/tests/DateRangeTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Ciloe\Ranges;
+
+use Ciloe\Ranges\DateRange;
+use Ciloe\Ranges\Exception\InvalidBoundException;
+use Ciloe\Ranges\Exception\InvalidInfiniteBoundException;
+use DateInterval;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class DateRangeTest extends TestCase
+{
+    public function testFromStringValidRanges()
+    {
+        $range = DateRange::fromString('[2025-06-04,2025-06-07]');
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $range->lower);
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $range->upper);
+        $this->assertEquals('[', $range->lowerBound);
+        $this->assertEquals(']', $range->upperBound);
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $range->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $range->getUpperBoundValue());
+
+        $range = DateRange::fromString('(2025-06-04,2025-06-07)');
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $range->lower);
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $range->upper);
+        $this->assertEquals('(', $range->lowerBound);
+        $this->assertEquals(')', $range->upperBound);
+        $this->assertEquals(new DateTimeImmutable('2025-06-05'), $range->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $range->getUpperBoundValue());
+
+        $range = DateRange::fromString('(,2025-06-07)');
+        $this->assertNull($range->lower);
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $range->upper);
+        $this->assertEquals('(', $range->lowerBound);
+        $this->assertEquals(')', $range->upperBound);
+        $this->assertNull($range->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $range->getUpperBoundValue());
+
+        $range = DateRange::fromString('(2025-06-04,)');
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $range->lower);
+        $this->assertNull($range->upper);
+        $this->assertEquals('(', $range->lowerBound);
+        $this->assertEquals(')', $range->upperBound);
+        $this->assertEquals(new DateTimeImmutable('2025-06-05'), $range->getLowerBoundValue());
+        $this->assertNull($range->getUpperBoundValue());
+    }
+
+    public function testFromStringInvalidRanges()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DateRange::fromString('invalid');
+    }
+
+    public function testFromStringInvalidInfiniteBounds()
+    {
+        $this->expectException(InvalidInfiniteBoundException::class);
+        DateRange::fromString('[,2025-06-07)');
+    }
+
+    public function testFromStringInvalidBounds()
+    {
+        $this->expectException(InvalidBoundException::class);
+        DateRange::fromString('[2025-06-07,2025-06-04]');
+    }
+
+    public function testContainsWithInclusiveBounds()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-04')));
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-05')));
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-06')));
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-07')));
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-03')));
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-08')));
+    }
+
+    public function testContainsWithExclusiveBounds()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '(',
+            ')'
+        );
+
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-04')));
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-05')));
+        $this->assertTrue($range->contains(new DateTimeImmutable('2025-06-06')));
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-07')));
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-03')));
+        $this->assertFalse($range->contains(new DateTimeImmutable('2025-06-08')));
+    }
+
+    public function testLength()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $this->assertEquals(4, $range->length());
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '(',
+            ')'
+        );
+
+        $this->assertEquals(2, $range->length());
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-04'),
+            '[',
+            ']'
+        );
+
+        $this->assertEquals(1, $range->length());
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-04'),
+            '(',
+            ')'
+        );
+
+        $this->assertEquals(0, $range->length());
+    }
+
+    public function testGenerateSeries()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $series = $range->generateSeries();
+        $this->assertCount(4, $series);
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $series[0]);
+        $this->assertEquals(new DateTimeImmutable('2025-06-05'), $series[1]);
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $series[2]);
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $series[3]);
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '(',
+            ')'
+        );
+
+        $series = $range->generateSeries();
+        $this->assertCount(2, $series);
+        $this->assertEquals(new DateTimeImmutable('2025-06-05'), $series[0]);
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $series[1]);
+    }
+
+    public function testToString()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $this->assertEquals('[2025-06-04,2025-06-07]', (string) $range);
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '(',
+            ')'
+        );
+
+        $this->assertEquals('(2025-06-04,2025-06-07)', (string) $range);
+
+        $range = new DateRange(
+            null,
+            new DateTimeImmutable('2025-06-07'),
+            '(',
+            ')'
+        );
+
+        $this->assertEquals('(,2025-06-07)', (string) $range);
+
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            null,
+            '(',
+            ')'
+        );
+
+        $this->assertEquals('(2025-06-04,)', (string) $range);
+    }
+
+    public function testOverlap()
+    {
+        $range1 = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $range2 = new DateRange(
+            new DateTimeImmutable('2025-06-06'),
+            new DateTimeImmutable('2025-06-10'),
+            '[',
+            ']'
+        );
+
+        $this->assertTrue($range1->overlap($range2));
+
+        $range3 = new DateRange(
+            new DateTimeImmutable('2025-06-08'),
+            new DateTimeImmutable('2025-06-10'),
+            '[',
+            ']'
+        );
+
+        $this->assertFalse($range1->overlap($range3));
+
+        $range4 = new DateRange(
+            new DateTimeImmutable('2025-06-07'),
+            new DateTimeImmutable('2025-06-10'),
+            '(',
+            ']'
+        );
+
+        $this->assertFalse($range1->overlap($range4));
+    }
+
+    public function testUnion()
+    {
+        $range1 = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $range2 = new DateRange(
+            new DateTimeImmutable('2025-06-06'),
+            new DateTimeImmutable('2025-06-10'),
+            '[',
+            ']'
+        );
+
+        $union = $range1->union($range2);
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $union->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-10'), $union->getUpperBoundValue());
+    }
+
+    public function testIntersection()
+    {
+        $range1 = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $range2 = new DateRange(
+            new DateTimeImmutable('2025-06-06'),
+            new DateTimeImmutable('2025-06-10'),
+            '[',
+            ']'
+        );
+
+        $intersection = $range1->intersection($range2);
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $intersection->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $intersection->getUpperBoundValue());
+
+        $range3 = new DateRange(
+            new DateTimeImmutable('2025-06-08'),
+            new DateTimeImmutable('2025-06-10'),
+            '[',
+            ']'
+        );
+
+        $this->assertNull($range1->intersection($range3));
+    }
+
+    public function testSplit()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $split = $range->split(new DateTimeImmutable('2025-06-06'));
+        $this->assertCount(2, $split);
+        $this->assertEquals(new DateTimeImmutable('2025-06-04'), $split[0]->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-05'), $split[0]->getUpperBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $split[1]->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-07'), $split[1]->getUpperBoundValue());
+    }
+
+    public function testShift()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $shifted = $range->shift(new DateInterval('P2D'));
+        $this->assertEquals(new DateTimeImmutable('2025-06-06'), $shifted->getLowerBoundValue());
+        $this->assertEquals(new DateTimeImmutable('2025-06-09'), $shifted->getUpperBoundValue());
+    }
+
+    public function testScaleNotSupported()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $range->scale(2);
+    }
+}

--- a/tests/DateRangeTest.php
+++ b/tests/DateRangeTest.php
@@ -6,6 +6,7 @@ namespace Tests\Ciloe\Ranges;
 
 use Ciloe\Ranges\DateRange;
 use Ciloe\Ranges\Exception\InvalidBoundException;
+use Ciloe\Ranges\Exception\InvalidDateIntervalException;
 use Ciloe\Ranges\Exception\InvalidInfiniteBoundException;
 use DateInterval;
 use DateTimeImmutable;
@@ -338,5 +339,30 @@ class DateRangeTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $range->scale(2);
+    }
+
+    public function testInvalidDateIntervalInConstructor()
+    {
+        $this->expectException(InvalidDateIntervalException::class);
+        new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']',
+            new DateInterval('PT1H') // 1 hour
+        );
+    }
+
+    public function testInvalidDateIntervalInShift()
+    {
+        $range = new DateRange(
+            new DateTimeImmutable('2025-06-04'),
+            new DateTimeImmutable('2025-06-07'),
+            '[',
+            ']'
+        );
+
+        $this->expectException(InvalidDateIntervalException::class);
+        $range->shift(new DateInterval('PT30M')); // 30 minutes
     }
 }


### PR DESCRIPTION
# Add DateRange class and documentation

## Description
This PR adds the new `DateRange` class to the Ranges library, allowing users to work with date ranges using DateTimeImmutable objects. The DateRange class implements the RangeInterface and provides functionality for creating, comparing, and transforming ranges of dates.

## Features
- Create date ranges with inclusive/exclusive bounds
- Check if a date is contained in a range
- Check if date ranges overlap
- Calculate date range length
- Create unions and intersections of date ranges
- Generate series of dates within a range
- Compare date ranges for equality
- Split date ranges at specific points
- Shift date ranges by time intervals
- Support for custom step intervals (days, weeks, months, etc.)

## Changes
- Added `DateRange` class in `src/DateRange.php`
- Added comprehensive documentation in `doc/DateRange.md`
- Updated README.md to include DateRange information and examples
- Updated CHANGELOG.md for version 0.0.2

## Testing
All functionality has been thoroughly tested with unit tests in `tests/DateRangeTest.php`.

## Documentation
- Added detailed documentation for the DateRange class
- Updated README with DateRange examples
- Updated CHANGELOG for version 0.0.2
